### PR TITLE
determine loader from content-type

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,8 @@ let loadSource = async ({path}) => {
     contents = contents.replace(pattern, comment)
   }
 
-  let {pathname} = new URL(source.url)
-  let loader = pathname.match(/[^.]+$/)[0]
+  let [contentType] = source.headers.get("content-type")?.split(";") || [];
+  let loader = loaderMap[contentType] || "default";
 
   return {contents, loader}
 }
@@ -51,5 +51,12 @@ let loadMap = async url => {
     reader.readAsDataURL(blob)
   })
 }
+
+let loaderMap = {
+  "application/javascript": "js",
+  "application/json": "json",
+  "text/plain": "text",
+  "text/css": "css",
+};
 
 export default {name, setup}


### PR DESCRIPTION
I wasn't able to use this easily with https://esm.sh/ as the URLs there do not use file extensions.
e.g., `import React from 'https://esm.sh/react@17.0.2'`

The extension can be specified by being more verbose, but the type definitions header is removed which is not ideal if using TypeScript.
e.g., `https://esm.sh/react@17.0.2/react.js`

Other content-type to loader mappings could be added as users need them.
I'd assume the ones I've added are more than enough for most.

A two-pronged approach could maybe be utilized to check both the content type and URL extension.
I could add this if preferred.